### PR TITLE
fix: formatting of python scripts

### DIFF
--- a/qemu_simple_test.py
+++ b/qemu_simple_test.py
@@ -14,83 +14,87 @@ import os
 
 
 class qemu_simple_test:
-	base_options='-M pseries -nographic -vga none'
+    base_options = '-M pseries -nographic -vga none'
 
-	def __init__(self, qemu='qemu-system-ppc64', memory='4G', cores=1, threads=1, kvm=False, virtio=False, kernel=None, initrd=None, cmdline=None, image=None, image_size='16G', image_cow=True, seed=None):
+    def __init__(self, qemu='qemu-system-ppc64', memory='4G', cores=1,
+                 threads=1, kvm=False, virtio=False, kernel=None, initrd=None,
+                 cmdline=None, image=None, image_size='16G', image_cow=True,
+                 seed=None):
 
-		self.qemu_cmd = '%s %s -m %s -smp cores=%d,threads=%d' % (qemu, self.base_options, memory, cores, threads)
+        self.qemu_cmd = '%s %s -m %s -smp cores=%d,threads=%d' % (
+            qemu, self.base_options, memory, cores, threads)
 
-		if kvm == True:
-			self.qemu_cmd = self.qemu_cmd + ' -enable-kvm'
+        if kvm is True:
+            self.qemu_cmd = self.qemu_cmd + ' -enable-kvm'
 
-		if kernel != None:
-			self.qemu_cmd = self.qemu_cmd + ' -kernel %s' % kernel
+        if kernel is not None:
+            self.qemu_cmd = self.qemu_cmd + ' -kernel %s' % kernel
 
-		if initrd != None:
-			self.qemu_cmd = self.qemu_cmd + ' -initrd %s' % initrd
+        if initrd is not None:
+            self.qemu_cmd = self.qemu_cmd + ' -initrd %s' % initrd
 
-		if cmdline != None:
-			self.qemu_cmd = self.qemu_cmd + ' -append \"%s\"' % cmdline
-		if virtio == True:
-			netdev='virtio-net-pci'
-			blockdev='virtio'
-		else:
-			netdev='spapr-vlan'
-			blockdev='scsi'
+        if cmdline is not None:
+            self.qemu_cmd = self.qemu_cmd + ' -append \"%s\"' % cmdline
+            if virtio is True:
+                netdev = 'virtio-net-pci'
+                blockdev = 'virtio'
+            else:
+                netdev = 'spapr-vlan'
+                blockdev = 'scsi'
 
-		self.qemu_cmd = self.qemu_cmd + ' -netdev type=%s,id=net0 -device %s,netdev=net0' % ('user', netdev)
+        self.qemu_cmd = self.qemu_cmd + ' -netdev type=%s,id=net0 \
+            -device %s,netdev=net0' % ('user', netdev)
 
-		if image_cow == True:
-			# Need the full path
-			image = os.path.abspath(image)
-			self.tmpimage = tempfile.NamedTemporaryFile()
-			cmd = 'qemu-img create -f qcow2 -o backing_file=%s %s %s' % (image, self.tmpimage.name, image_size)
-			print cmd
-			retcode = subprocess.call(cmd, shell=True)
-			if retcode != 0:
-				raise ValueError
-			image = self.tmpimage.name
+        if image_cow is True:
+            # Need the full path
+            image = os.path.abspath(image)
+            self.tmpimage = tempfile.NamedTemporaryFile()
+            cmd = 'qemu-img create -f qcow2 -o backing_file=%s %s %s' \
+                % (image, self.tmpimage.name, image_size)
+            print cmd
+            retcode = subprocess.call(cmd, shell=True)
+            if retcode != 0:
+                raise ValueError
+            image = self.tmpimage.name
 
-		self.qemu_cmd = self.qemu_cmd + ' -drive file=%s,if=%s' % (image, blockdev)
+        self.qemu_cmd = self.qemu_cmd + ' \
+            -drive file=%s,if=%s' % (image, blockdev)
 
-		if seed:
-			self.qemu_cmd = self.qemu_cmd + ' -drive file=%s,if=%s' % (seed, blockdev)
+        if seed:
+            self.qemu_cmd = self.qemu_cmd + ' \
+                -drive file=%s,if=%s' % (seed, blockdev)
 
+    def start(self):
+        self.child = pexpect.spawn(self.qemu_cmd)
+        self.child.logfile = sys.stdout
+        # We sometimes get failures in close(), bump the timeouts
+        self.child.delayafterclose = 1
+        self.child.delayafterterminate = 1
 
-	def start(self):
-		self.child = pexpect.spawn(self.qemu_cmd)
-		self.child.logfile = sys.stdout
-		# We sometimes get failures in close(), bump the timeouts
-		self.child.delayafterclose = 1
-		self.child.delayafterterminate = 1
+    def expectcheck(self, str, timeout=300):
+        keys = [str,
+                pexpect.TIMEOUT,
+                pexpect.EOF,
+                'kernel BUG',
+                'BUG:',
+                'Kernel panic',
+                'Call Trace:',
+                'Rebooting in:',
+                'Boot has failed, sleeping forever',
+                ]
 
+        result = self.child.expect(keys, timeout)
 
-	def expectcheck(self, str, timeout=300):
-		keys = [ str,
-			pexpect.TIMEOUT,
-			pexpect.EOF,
-			'kernel BUG',
-			'BUG:',
-			'Kernel panic',
-			'Call Trace:',
-			'Rebooting in:',
-			'Boot has failed, sleeping forever',
-		]
+        if result == 1:
+            raise Exception('Timeout')
+        elif result == 2:
+            raise Exception('EOF')
+        elif result != 0:
+            raise Exception('Boot failure')
 
-		result = self.child.expect(keys, timeout)
+    def interact(self):
+        self.child.logfile = None
+        self.child.interact()
 
-		if result == 1:
-			raise Exception('Timeout')
-		elif result == 2:
-			raise Exception('EOF')
-		elif result != 0:
-			raise Exception('Boot failure')
-
-
-	def interact(self):
-		self.child.logfile = None
-		self.child.interact()
-
-
-	def close(self):
-		self.child.close()
+    def close(self):
+        self.child.close()

--- a/qemu_ubuntu_kernel_rebootme.py
+++ b/qemu_ubuntu_kernel_rebootme.py
@@ -5,16 +5,17 @@ from qemu_ubuntu_test import qemu_ubuntu_test
 
 
 if len(sys.argv) != 3:
-	print "Usage: qemu_ubuntu_kernel_rebootme.py kernel iterations"
-	sys.exit(1)
+    print "Usage: qemu_ubuntu_kernel_rebootme.py kernel iterations"
+    sys.exit(1)
 
-kernel=sys.argv[1]
-iterations=int(sys.argv[2])
+kernel = sys.argv[1]
+iterations = int(sys.argv[2])
 
-q = qemu_ubuntu_test(kvm=True, cores=8, threads=8, kernel=kernel, cmdline='root=/dev/sda1 rw', virtio=True)
+q = qemu_ubuntu_test(kvm=True, cores=8, threads=8, kernel=kernel,
+                     cmdline='root=/dev/sda1 rw', virtio=True)
 q.boot()
 
 for i in range(iterations):
-	q.login()
-	q.child.sendline('shutdown -r now')
-	q.wait_for_login()
+    q.login()
+    q.child.sendline('shutdown -r now')
+    q.wait_for_login()

--- a/qemu_ubuntu_kernel_test.py
+++ b/qemu_ubuntu_kernel_test.py
@@ -5,10 +5,10 @@ from qemu_ubuntu_test import qemu_ubuntu_test
 
 
 if len(sys.argv) != 2:
-	print "Usage: qemu_ubuntu_kernel_test.py kernel"
-	sys.exit(1)
+    print "Usage: qemu_ubuntu_kernel_test.py kernel"
+    sys.exit(1)
 
-kernel=sys.argv[1]
+kernel = sys.argv[1]
 
 print "Testing PAPR virtual IO"
 q = qemu_ubuntu_test(kvm=True, kernel=kernel, cmdline='root=/dev/sda1 rw')
@@ -16,12 +16,14 @@ q.simple_test(timeout=30)
 q.close()
 
 print "Testing virtio virtual IO"
-q = qemu_ubuntu_test(kvm=True, kernel=kernel, cmdline='root=/dev/vda1 rw', virtio=True)
+q = qemu_ubuntu_test(kvm=True, kernel=kernel, cmdline='root=/dev/vda1 rw',
+                     virtio=True)
 q.simple_test(timeout=30)
 q.close()
 
 print "Testing SMP"
-q = qemu_ubuntu_test(kvm=True, cores=8, threads=8, kernel=kernel, cmdline='root=/dev/sda1 rw')
+q = qemu_ubuntu_test(kvm=True, cores=8, threads=8, kernel=kernel,
+                     cmdline='root=/dev/sda1 rw')
 q.simple_test(timeout=30)
 q.close()
 

--- a/qemu_ubuntu_qemu_test.py
+++ b/qemu_ubuntu_qemu_test.py
@@ -5,10 +5,10 @@ from qemu_ubuntu_test import qemu_ubuntu_test
 
 
 if len(sys.argv) != 2:
-	print "Usage: qemu_ubuntu_qemu_test.py qemu_binary"
-	sys.exit(1)
+    print "Usage: qemu_ubuntu_qemu_test.py qemu_binary"
+    sys.exit(1)
 
-qemu=sys.argv[1]
+qemu = sys.argv[1]
 
 print "Testing PAPR virtual IO"
 q = qemu_ubuntu_test(qemu=qemu, kvm=False)

--- a/qemu_ubuntu_quick_test.py
+++ b/qemu_ubuntu_quick_test.py
@@ -5,10 +5,10 @@ from qemu_ubuntu_test import qemu_ubuntu_test
 
 
 if len(sys.argv) != 2:
-	print "Usage: qemu_ubuntu_quick_test.py kernel"
-	sys.exit(1)
+    print "Usage: qemu_ubuntu_quick_test.py kernel"
+    sys.exit(1)
 
-kernel=sys.argv[1]
+kernel = sys.argv[1]
 
 print "Testing PAPR virtual IO"
 q = qemu_ubuntu_test(kvm=False, kernel=kernel, cmdline='root=/dev/sda1 rw')

--- a/qemu_ubuntu_test.py
+++ b/qemu_ubuntu_test.py
@@ -6,52 +6,57 @@ import urllib
 
 
 class qemu_ubuntu_test(qemu_simple_test):
-	def __init__(self, qemu='qemu-system-ppc64', memory='4G', cores=1, threads=1, kvm=False, virtio=False, kernel=None, initrd=None, cmdline=None, image='utopic-server-cloudimg-ppc64el-disk1.img', image_size='16G', image_cow=True, seed='my-seed.img', seedurl='http://ozlabs.org/~anton/my-seed.img', imageurl='http://cloud-images.ubuntu.com/utopic/current/utopic-server-cloudimg-ppc64el-disk1.img'):
+    def __init__(self, qemu='qemu-system-ppc64', memory='4G', cores=1,
+                 threads=1, kvm=False, virtio=False, kernel=None, initrd=None,
+                 cmdline=None, image='utopic-server-cloudimg-ppc64el-disk1.img',
+                 image_size='16G', image_cow=True, seed='my-seed.img',
+                 seedurl='http://ozlabs.org/~anton/my-seed.img',
+                 imageurl='http://cloud-images.ubuntu.com/utopic/current/utopic\
+                    -server-cloudimg-ppc64el-disk1.img'):
 
-		qemu_simple_test.__init__(self, qemu=qemu, memory=memory, cores=cores, threads=threads, kvm=kvm, virtio=virtio, kernel=kernel, initrd=initrd, cmdline=cmdline, image=image, image_size=image_size, image_cow=image_cow, seed=seed)
+        qemu_simple_test.__init__(self, qemu=qemu, memory=memory, cores=cores,
+                                  threads=threads, kvm=kvm, virtio=virtio,
+                                  kernel=kernel, initrd=initrd, cmdline=cmdline,
+                                  image=image, image_size=image_size,
+                                  image_cow=image_cow, seed=seed)
 
-		if os.path.isfile(seed) == False:
-			urllib.urlretrieve(seedurl, seed)
+        if os.path.isfile(seed) is False:
+            urllib.urlretrieve(seedurl, seed)
 
-		if os.path.isfile(image) == False:
-			urllib.urlretrieve(imageurl, image)
+        if os.path.isfile(image) is False:
+            urllib.urlretrieve(imageurl, image)
 
+    def wait_for_login(self, timeout=300):
+        self.expectcheck('ubuntu login:', timeout=timeout)
 
-	def wait_for_login(self, timeout=300):
-		self.expectcheck('ubuntu login:', timeout=timeout)
+    def wait_for_prompt(self, timeout=300):
+        self.child.expect('ubuntu@ubuntu', timeout=timeout)
 
+    def boot(self, timeout=300):
+        # boot it
+        self.start()
+        self.wait_for_login(timeout=timeout)
 
-	def wait_for_prompt(self, timeout=300):
-		self.child.expect('ubuntu@ubuntu', timeout=timeout)
+    def login(self, timeout=300):
+        # log in
+        self.child.sendline('ubuntu')
+        self.child.expect('Password:', timeout=timeout)
+        self.child.sendline('passw0rd')
+        self.wait_for_prompt(timeout=timeout)
 
+    def simple_test(self, timeout=300):
+        self.boot(timeout=timeout)
+        self.login(timeout=timeout)
 
-	def boot(self, timeout=300):
-		# boot it
-		self.start()
-		self.wait_for_login(timeout=timeout)
+        # quick network test
+        self.child.sendline('ping -W 1 -c 1 10.0.2.2')
+        self.child.expect('1 received', timeout=timeout)
+        self.wait_for_prompt(timeout=timeout)
 
+        # more involved network test
+        self.child.sendline('wget http://ozlabs.org/~anton/datafile')
+        self.wait_for_prompt(timeout=timeout)
 
-	def login(self, timeout=300):
-		# log in
-		self.child.sendline('ubuntu')
-		self.child.expect('Password:', timeout=timeout)
-		self.child.sendline('passw0rd')
-		self.wait_for_prompt(timeout=timeout)
-
-
-	def simple_test(self, timeout=300):
-		self.boot(timeout=timeout)
-		self.login(timeout=timeout)
-
-		# quick network test
-		self.child.sendline('ping -W 1 -c 1 10.0.2.2')
-		self.child.expect('1 received', timeout=timeout)
-		self.wait_for_prompt(timeout=timeout)
-
-		# more involved network test
-		self.child.sendline('wget http://ozlabs.org/~anton/datafile')
-		self.wait_for_prompt(timeout=timeout)
-
-		self.child.sendline('md5sum datafile')
-		self.child.expect('2a9981457d46bf85eba3f81728159f84', timeout=timeout)
-		self.wait_for_prompt(timeout=timeout)
+        self.child.sendline('md5sum datafile')
+        self.child.expect('2a9981457d46bf85eba3f81728159f84', timeout=timeout)
+        self.wait_for_prompt(timeout=timeout)


### PR DESCRIPTION
In theory this shouldn't break anything.. just a clean up the scripts to make them pep8 compliant and a little more readable. A few pythonisms adjusted, like; "if this == True" changed to "if this is True" (could also be "if this") and "this=that" to "this = that".

Could clone a job in jenkins to run the tests off a branch before merging to master if you like.